### PR TITLE
fix quotes on profile pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -226,21 +226,10 @@ img.profile_avatar {
   font-size: 10px;
 }
 
-.profile_quote_thumb {
-  width: 100%;
-  height: auto;
-  margin-bottom: 10px;
-  text-align: center;
-  padding: 0;
-  border: 1px solid #cacaca;
-  margin: 5px;
-  display: inline-block;
-  vertical-align: top;
-}
-
 .quote_list {
-  margin: 15px;
-}
+    padding: 30px;
+  }
+
 /* Quote View Styling */
 .quote_avatar {
   border-radius: 28em;

--- a/app/assets/stylesheets/quotes.scss
+++ b/app/assets/stylesheets/quotes.scss
@@ -88,6 +88,8 @@
   text-decoration: none;
 }
 
+/* Share Bar improvements */
+
 #share-bar {
   position: absolute;
   bottom: 0px;
@@ -111,4 +113,25 @@
     display: inline-block;
     height: 40px !important;
     width: 30px !important;
+}
+
+
+/* Really messy unfinished stuff for profile quotes */
+
+.profile_quote_thumb {
+  text-align: center;
+  height: 200px;
+  padding: 5px;
+  display: inline-block;
+  width: 30%;
+  min-width: 320px;
+  float: left;
+  margin: 10px;
+}
+
+.profile_quote_text {
+  color: #fff;
+  font-weight: 600;
+  font-size: 26px;
+  margin-top: 2em;
 }

--- a/app/views/quotes/show.html.erb
+++ b/app/views/quotes/show.html.erb
@@ -1,6 +1,4 @@
 <div id="quote" style="background:url(<%= @quote.image.url -%>); background-size:cover; background-attachment: fixed;">
-  <div class="quote-bg">
-  </div>
   <div class="quote-actions">
     <% if current_user && current_user == @quote.user %>
     <%= link_to edit_quote_path(@quote) do %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,3 @@
-
 <div class="container-fluid">
   <div class="row">
     <div class="profile_header">
@@ -66,19 +65,17 @@
 
 
 <div class="quote_list">
-<div class="row">
-<% @user.quotes.each do |quote| %>
-  <div class="user_quote_body">
-    <% if quote.user.present? %>
-    <%= link_to quote, class: :"quote_link" do %>
-      <div class="profile_quote_thumb" style="background:url(<%= quote.image.url -%>); background-size:cover; background-attachment: fixed;>
-        <%= quote.citation %>
-        <%= image_tag quote.image, class:'img_thumb' %>
+  <div class="row">
+  <% @user.quotes.each do |quote| %>
+      <% if quote.user.present? %>
+        <div class="profile_quote_thumb" style="background:url(<%= quote.image.url -%>); background-size:cover;">
+          <%= link_to quote, class: :"quote_link" do %>
+            <div class="profile_quote_text">
+              <%= quote.citation %>
+              </div>
+      <% end %>
         </div>
     <% end %>
+      <% end %>
     </div>
-  </div>
-    <% end %>
-<% end %>
-  </div>
 </div>


### PR DESCRIPTION
Thumbnails on profile pages look like this now:

<img width="1294" alt="quothme" src="https://cloud.githubusercontent.com/assets/401560/21290942/45f70b74-c482-11e6-9a6f-a79518ad87f3.png">
